### PR TITLE
added include for static embree library

### DIFF
--- a/cmake/ospray_macros.cmake
+++ b/cmake/ospray_macros.cmake
@@ -52,6 +52,10 @@ macro(ospray_find_embree EMBREE_VERSION_REQUIRED)
     message(STATUS "Found Embree v${EMBREE_VERSION}: ${EMBREE_LIBRARY}")
   endif()
 
+  if (EMBREE_STATIC_LIB)
+    # use import target to include full static lib chain
+    set(EMBREE_LIBRARY embree)
+  endif()
   set(EMBREE_LIBRARIES ${EMBREE_LIBRARY})
 endmacro()
 


### PR DESCRIPTION
Hello,

This pull request adds a small section to `ospray_macros.cmake` to properly include Embree as a static library if it is built statically. This relies on [Embree pull request 227](https://github.com/embree/embree/pull/227).

This has been verified using OSPRay 1.7.x build.