### PR TITLE
Some fixes in the cpp interface

### DIFF
--- a/ospray/include/ospray/ospray_cpp/Data.h
+++ b/ospray/include/ospray/ospray_cpp/Data.h
@@ -45,7 +45,7 @@ class Data : public ManagedObject<OSPData, OSP_DATA>
   // Set a single object as a 1-item data array
 
   template <typename T>
-  Data(const T &obj);
+  explicit Data(const T &obj);
 
   // Construct from an existing OSPData handle (cpp::Data then owns handle)
 

--- a/ospray/include/ospray/ospray_cpp/Instance.h
+++ b/ospray/include/ospray/ospray_cpp/Instance.h
@@ -11,7 +11,7 @@ namespace cpp {
 class Instance : public ManagedObject<OSPInstance, OSP_INSTANCE>
 {
  public:
-  Instance(Group &group);
+  Instance(const Group &group);
   Instance(OSPGroup group);
   Instance(OSPInstance existing = nullptr);
 };
@@ -21,7 +21,7 @@ static_assert(sizeof(Instance) == sizeof(OSPInstance),
 
 // Inlined function definitions ///////////////////////////////////////////
 
-inline Instance::Instance(Group &group) : Instance(group.handle()) {}
+inline Instance::Instance(const Group &group) : Instance(group.handle()) {}
 
 inline Instance::Instance(OSPGroup group)
 {

--- a/ospray/include/ospray/ospray_cpp/ManagedObject.h
+++ b/ospray/include/ospray/ospray_cpp/ManagedObject.h
@@ -30,6 +30,9 @@ class ManagedObject
   ManagedObject &operator=(const ManagedObject<HANDLE_T, TYPE> &copy);
   ManagedObject &operator=(ManagedObject<HANDLE_T, TYPE> &&move);
 
+  bool operator==(const ManagedObject<HANDLE_T, TYPE> &other) const;
+  bool operator!=(const ManagedObject<HANDLE_T, TYPE> &other) const;
+
   template <typename T>
   void setParam(const std::string &name, const T &v) const;
 
@@ -182,6 +185,20 @@ template <typename HANDLE_T, OSPDataType TYPE>
 inline ManagedObject<HANDLE_T, TYPE>::operator bool() const
 {
   return handle() != nullptr;
+}
+
+template <typename HANDLE_T, OSPDataType TYPE>
+inline bool ManagedObject<HANDLE_T, TYPE>::operator==(
+    const ManagedObject<HANDLE_T, TYPE> &other) const
+{
+  return handle() == other.handle();
+}
+
+template <typename HANDLE_T, OSPDataType TYPE>
+inline bool ManagedObject<HANDLE_T, TYPE>::operator!=(
+    const ManagedObject<HANDLE_T, TYPE> &other) const
+{
+  return !(*this == other);
 }
 
 } // namespace cpp


### PR DESCRIPTION
I would like to propose a few smaller fixes to OSPRay's C++ interface layer.

1.  Add missing `const` keyword to constructor `Instance(Group &group)` -> `Instance(const Group &group)`
2. Add missing comparison operators to class template `ManagedObject` to enable use cases like the following:
```
std::vector<ospray::cpp::Light> oldLights;
std::vector<ospray::cpp::Light> newLights;
...
if(newLights != oldLights) {
  world.setParam("light", ospray::cpp::CopiedData(newLights));
  world.commit();
}
```
3. Mark constructor `Data(const T &obj)` as `explicit` to avoid compiler error in the following kind of code:
```
struct MyColorStruct { ... };
std::variant<ospray::cpp::Data, MyColorStruct> colors;
```
which otherwise fails to compile with a static assert error in the `Data<SHARED>::validate_element_type()` method.